### PR TITLE
modify benchmark.py and add model/mlp.py

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,5 +16,5 @@
 # limitations under the License.
 #
 
-ADD_SUBDIRECTORY(cifar10)
-ADD_SUBDIRECTORY(imagenet/alexnet)
+ADD_SUBDIRECTORY(cpp/imagenet)
+ADD_SUBDIRECTORY(cpp/cifar10)

--- a/examples/cnn/benchmark.py
+++ b/examples/cnn/benchmark.py
@@ -23,241 +23,11 @@
 from singa import opt
 from singa import device
 from singa import tensor
-from singa import module
-from singa import autograd
 
+import argparse
 import time
 import numpy as np
 from tqdm import trange
-
-
-def conv3x3(in_planes, out_planes, stride=1):
-    """3x3 convolution with padding"""
-    return autograd.Conv2d(
-        in_planes,
-        out_planes,
-        kernel_size=3,
-        stride=stride,
-        padding=1,
-        bias=False,
-    )
-
-
-class BasicBlock(autograd.Layer):
-    expansion = 1
-
-    def __init__(self, inplanes, planes, stride=1, downsample=None):
-        super(BasicBlock, self).__init__()
-        self.conv1 = conv3x3(inplanes, planes, stride)
-        self.bn1 = autograd.BatchNorm2d(planes)
-        self.conv2 = conv3x3(planes, planes)
-        self.bn2 = autograd.BatchNorm2d(planes)
-        self.downsample = downsample
-        self.stride = stride
-
-    def __call__(self, x):
-        residual = x
-
-        out = self.conv1(x)
-        out = self.bn1(out)
-        out = autograd.relu(out)
-
-        out = self.conv2(out)
-        out = self.bn2(out)
-
-        if self.downsample is not None:
-            residual = self.downsample(x)
-
-        out = autograd.add(out, residual)
-        out = autograd.relu(out)
-
-        return out
-
-
-class Bottleneck(autograd.Layer):
-    expansion = 4
-
-    def __init__(self, inplanes, planes, stride=1, downsample=None):
-        super(Bottleneck, self).__init__()
-        self.conv1 = autograd.Conv2d(inplanes,
-                                     planes,
-                                     kernel_size=1,
-                                     bias=False)
-        self.bn1 = autograd.BatchNorm2d(planes)
-        self.conv2 = autograd.Conv2d(planes,
-                                     planes,
-                                     kernel_size=3,
-                                     stride=stride,
-                                     padding=1,
-                                     bias=False)
-        self.bn2 = autograd.BatchNorm2d(planes)
-        self.conv3 = autograd.Conv2d(planes,
-                                     planes * self.expansion,
-                                     kernel_size=1,
-                                     bias=False)
-        self.bn3 = autograd.BatchNorm2d(planes * self.expansion)
-
-        self.downsample = downsample
-        self.stride = stride
-
-    def __call__(self, x):
-        residual = x
-
-        out = self.conv1(x)
-        out = self.bn1(out)
-        out = autograd.relu(out)
-
-        out = self.conv2(out)
-        out = self.bn2(out)
-        out = autograd.relu(out)
-
-        out = self.conv3(out)
-        out = self.bn3(out)
-
-        if self.downsample is not None:
-            residual = self.downsample(x)
-
-        out = autograd.add(out, residual)
-        out = autograd.relu(out)
-
-        return out
-
-
-__all__ = [
-    'ResNet', 'resnet18', 'resnet34', 'resnet50', 'resnet101', 'resnet152'
-]
-
-
-class ResNet(module.Module):
-
-    def __init__(self, block, layers, num_classes=1000):
-        self.inplanes = 64
-        super(ResNet, self).__init__()
-        self.conv1 = autograd.Conv2d(3,
-                                     64,
-                                     kernel_size=7,
-                                     stride=2,
-                                     padding=3,
-                                     bias=False)
-        self.bn1 = autograd.BatchNorm2d(64)
-        self.maxpool = autograd.MaxPool2d(kernel_size=3, stride=2, padding=1)
-        self.layer1 = self._make_layer(block, 64, layers[0])
-        self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
-        self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
-        self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
-        self.avgpool = autograd.AvgPool2d(7, stride=1)
-        self.fc = autograd.Linear(512 * block.expansion, num_classes)
-
-    def _make_layer(self, block, planes, blocks, stride=1):
-        downsample = None
-        if stride != 1 or self.inplanes != planes * block.expansion:
-            conv = autograd.Conv2d(
-                self.inplanes,
-                planes * block.expansion,
-                kernel_size=1,
-                stride=stride,
-                bias=False,
-            )
-            bn = autograd.BatchNorm2d(planes * block.expansion)
-
-            def _downsample(x):
-                return bn(conv(x))
-
-            downsample = _downsample
-
-        layers = []
-        layers.append(block(self.inplanes, planes, stride, downsample))
-        self.inplanes = planes * block.expansion
-        for i in range(1, blocks):
-            layers.append(block(self.inplanes, planes))
-
-        def forward(x):
-            for layer in layers:
-                x = layer(x)
-            return x
-
-        return forward
-
-    def forward(self, x):
-        x = self.conv1(x)
-        x = self.bn1(x)
-        x = autograd.relu(x)
-        x = self.maxpool(x)
-
-        x = self.layer1(x)
-        x = self.layer2(x)
-        x = self.layer3(x)
-        x = self.layer4(x)
-
-        x = self.avgpool(x)
-        x = autograd.flatten(x)
-        x = self.fc(x)
-
-        return x
-
-    def loss(self, out, ty):
-        return autograd.softmax_cross_entropy(out, ty)
-
-    def optim(self, loss):
-        self.optimizer.backward_and_update(loss)
-
-    def set_optimizer(self, optimizer):
-        self.optimizer = optimizer
-
-
-def resnet18(pretrained=False, **kwargs):
-    """Constructs a ResNet-18 model.
-
-    Args:
-        pretrained (bool): If True, returns a model pre-trained on ImageNet
-    """
-    model = ResNet(BasicBlock, [2, 2, 2, 2], **kwargs)
-
-    return model
-
-
-def resnet34(pretrained=False, **kwargs):
-    """Constructs a ResNet-34 model.
-
-    Args:
-        pretrained (bool): If True, returns a model pre-trained on ImageNet
-    """
-    model = ResNet(BasicBlock, [3, 4, 6, 3], **kwargs)
-
-    return model
-
-
-def resnet50(pretrained=False, **kwargs):
-    """Constructs a ResNet-50 model.
-
-    Args:
-        pretrained (bool): If True, returns a model pre-trained on ImageNet
-    """
-    model = ResNet(Bottleneck, [3, 4, 6, 3], **kwargs)
-
-    return model
-
-
-def resnet101(pretrained=False, **kwargs):
-    """Constructs a ResNet-101 model.
-
-    Args:
-        pretrained (bool): If True, returns a model pre-trained on ImageNet
-    """
-    model = ResNet(Bottleneck, [3, 4, 23, 3], **kwargs)
-
-    return model
-
-
-def resnet152(pretrained=False, **kwargs):
-    """Constructs a ResNet-152 model.
-
-    Args:
-        pretrained (bool): If True, returns a model pre-trained on ImageNet
-    """
-    model = ResNet(Bottleneck, [3, 8, 36, 3], **kwargs)
-
-    return model
 
 
 def train_resnet(DIST=True, graph=True, sequential=False):
@@ -267,16 +37,20 @@ def train_resnet(DIST=True, graph=True, sequential=False):
     batch_size = 32
     sgd = opt.SGD(lr=0.1, momentum=0.9, weight_decay=1e-5)
 
-    local_rank = 0
-    world_size = 1
-    global_rank = 0
     IMG_SIZE = 224
 
+    # For distributed training, sequential has better throughput in the current version
     if DIST:
         sgd = opt.DistOpt(sgd)
         world_size = sgd.world_size
         local_rank = sgd.local_rank
         global_rank = sgd.global_rank
+        sequential = True
+    else:
+        local_rank = 0
+        world_size = 1
+        global_rank = 0
+        sequential = False
 
     dev = device.create_cuda_gpu_on(local_rank)
 
@@ -288,7 +62,9 @@ def train_resnet(DIST=True, graph=True, sequential=False):
     ty.copy_from_numpy(y)
 
     # construct the model
-    model = resnet50()
+    from model import resnet
+    model = resnet.resnet50(num_channels=3, num_classes=1000)
+
     model.train()
     model.on_device(dev)
     model.set_optimizer(sgd)
@@ -301,7 +77,7 @@ def train_resnet(DIST=True, graph=True, sequential=False):
         for _ in t:
             out = model(tx)
             loss = model.loss(out, ty)
-            model.optim(loss)
+            model.optim(loss, dist_option='fp32', spars=None)
 
     dev.Sync()
     end = time.time()
@@ -315,12 +91,21 @@ def train_resnet(DIST=True, graph=True, sequential=False):
 
 if __name__ == "__main__":
 
-    DIST = True
-    graph = True
-    sequential = False
+    parser = argparse.ArgumentParser(
+        description='Throughput test using Resnet 50')
+    parser.add_argument('--dist',
+                        '--enable-dist',
+                        default='False',
+                        action='store_true',
+                        help='enable distributed training',
+                        dest='DIST')
+    parser.add_argument('--no-graph',
+                        '--disable-graph',
+                        default='True',
+                        action='store_false',
+                        help='disable graph',
+                        dest='graph')
 
-    # For distributed training, sequential has better throughput in the current version
-    if DIST:
-        sequential = True
+    args = parser.parse_args()
 
-    train_resnet(DIST=DIST, graph=graph, sequential=sequential)
+    train_resnet(DIST=args.DIST, graph=args.graph)

--- a/examples/cnn/model/mlp.py
+++ b/examples/cnn/model/mlp.py
@@ -1,0 +1,92 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from singa import module
+from singa import autograd
+from singa import tensor
+from singa.tensor import Tensor
+
+class MLP(module.Module):
+
+    def __init__(self, data_size=10, perceptron_size=100, num_classes=10):
+        super(MLP, self).__init__()
+        self.num_classes = num_classes
+        self.dimension = 2
+
+        self.w0 = Tensor(shape=(data_size, perceptron_size),
+                         requires_grad=True,
+                         stores_grad=True)
+        self.w0.gaussian(0.0, 0.1)
+        self.b0 = Tensor(shape=(perceptron_size,),
+                         requires_grad=True,
+                         stores_grad=True)
+        self.b0.set_value(0.0)
+
+        self.w1 = Tensor(shape=(perceptron_size, num_classes),
+                         requires_grad=True,
+                         stores_grad=True)
+        self.w1.gaussian(0.0, 0.1)
+        self.b1 = Tensor(shape=(num_classes,),
+                         requires_grad=True,
+                         stores_grad=True)
+        self.b1.set_value(0.0)
+
+    def forward(self, inputs):
+        x = autograd.matmul(inputs, self.w0)
+        x = autograd.add_bias(x, self.b0)
+        x = autograd.relu(x)
+        x = autograd.matmul(x, self.w1)
+        x = autograd.add_bias(x, self.b1)
+        return x
+
+    def loss(self, out, ty):
+        return autograd.softmax_cross_entropy(out, ty)
+
+    def optim(self, loss, dist_option, spars):
+        if dist_option == 'fp32':
+            self.optimizer.backward_and_update(loss)
+        elif dist_option == 'fp16':
+            self.optimizer.backward_and_update_half(loss)
+        elif dist_option == 'partialUpdate':
+            self.optimizer.backward_and_partial_update(loss)
+        elif dist_option == 'sparseTopK':
+            self.optimizer.backward_and_sparse_update(loss,
+                                                      topK=True,
+                                                      spars=spars)
+        elif dist_option == 'sparseThreshold':
+            self.optimizer.backward_and_sparse_update(loss,
+                                                      topK=False,
+                                                      spars=spars)
+
+    def set_optimizer(self, optimizer):
+        self.optimizer = optimizer
+
+
+def create_model(pretrained=False, **kwargs):
+    """Constructs a CNN model.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained
+    """
+    model = MLP(**kwargs)
+
+    return model
+
+
+__all__ = ['MLP', 'create_model']


### PR DESCRIPTION
1. throughput.py

```
root@71ac539cda77:~/dcsysh/singa/examples/cnn# python3 benchmark.py
100%|##########################################################################################################################| 100/100 [00:13<00:00,  7.36it/s]
Throughput = 235.44919764266842 per second
TotalTime=13.591042280197144
Total=0.13591042280197144
root@71ac539cda77:~/dcsysh/singa/examples/cnn# mpiexec --np 2 python3 benchmark.py --dist
100%|##########| 100/100 [00:14<00:00,  6.88it/s]Throughput = 439.56339958690756 per second
TotalTime=14.55990195274353
Total=0.1455990195274353
```

2. model/mlp.py

```
root@71ac539cda77:~/dcsysh/singa/examples/cnn# python3 train.py mlp mnist
Starting Epoch 0:
Training loss = 485.473358, training accuracy = 0.851771
Evaluation accuracy = 0.911358, Elapsed Time = 0.662090s
Starting Epoch 1:
Training loss = 267.414551, training accuracy = 0.918657
Evaluation accuracy = 0.928986, Elapsed Time = 0.612019s
Starting Epoch 2:
Training loss = 219.956863, training accuracy = 0.932998
Evaluation accuracy = 0.937400, Elapsed Time = 0.606485s
Starting Epoch 3:
Training loss = 188.373474, training accuracy = 0.942519
Evaluation accuracy = 0.946715, Elapsed Time = 0.607862s
Starting Epoch 4:
Training loss = 164.958145, training accuracy = 0.949223
Evaluation accuracy = 0.951723, Elapsed Time = 0.609377s
Starting Epoch 5:
Training loss = 146.759750, training accuracy = 0.954442
Evaluation accuracy = 0.956330, Elapsed Time = 0.609745s
Starting Epoch 6:
Training loss = 132.402222, training accuracy = 0.959178
Evaluation accuracy = 0.958534, Elapsed Time = 0.607757s
Starting Epoch 7:
Training loss = 120.471268, training accuracy = 0.963114
Evaluation accuracy = 0.961639, Elapsed Time = 0.608525s
Starting Epoch 8:
Training loss = 110.338516, training accuracy = 0.966832
Evaluation accuracy = 0.963642, Elapsed Time = 0.609457s
Starting Epoch 9:
Training loss = 101.753929, training accuracy = 0.968450
Evaluation accuracy = 0.966947, Elapsed Time = 0.608664s
root@71ac539cda77:~/dcsysh/singa/examples/cnn# python3 train.py mlp cifar10
Starting Epoch 0:
Training loss = 1560.984497, training accuracy = 0.323504
Evaluation accuracy = 0.354868, Elapsed Time = 0.691894s
Starting Epoch 1:
Training loss = 1337.684814, training accuracy = 0.396327
Evaluation accuracy = 0.398037, Elapsed Time = 0.690867s
Starting Epoch 2:
Training loss = 1263.678955, training accuracy = 0.430498
Evaluation accuracy = 0.412760, Elapsed Time = 0.687694s
Starting Epoch 3:
Training loss = 1214.546997, training accuracy = 0.453585
Evaluation accuracy = 0.427885, Elapsed Time = 0.690568s
Starting Epoch 4:
Training loss = 1174.774658, training accuracy = 0.469310
Evaluation accuracy = 0.441106, Elapsed Time = 0.683620s
Starting Epoch 5:
Training loss = 1142.419312, training accuracy = 0.483395
Evaluation accuracy = 0.437200, Elapsed Time = 0.688536s
Starting Epoch 6:
Training loss = 1112.198486, training accuracy = 0.497759
Evaluation accuracy = 0.430889, Elapsed Time = 0.689256s
Starting Epoch 7:
Training loss = 1082.584961, training accuracy = 0.510563
Evaluation accuracy = 0.447516, Elapsed Time = 0.691370s
Starting Epoch 8:
Training loss = 1060.778320, training accuracy = 0.521627
Evaluation accuracy = 0.453125, Elapsed Time = 0.691361s
Starting Epoch 9:
Training loss = 1039.045410, training accuracy = 0.529289
Evaluation accuracy = 0.449920, Elapsed Time = 0.688094s
```
